### PR TITLE
v2 auth - return an endpoint when no region is given 

### DIFF
--- a/swiftly/client/standardclient.py
+++ b/swiftly/client/standardclient.py
@@ -349,7 +349,7 @@ class StandardClient(Client):
                 self.default_region = \
                     body['access']['user'].get('RAX-AUTH:defaultRegion')
                 region = self.region or self.default_region or ''
-                storage_match1 = storage_match2 = storage_match3 \
+                storage_match1 = storage_match2 = storage_match3 = \
                     storage_match4 = None
                 cdn_match1 = cdn_match2 = cdn_match3 = None
                 for service in body['access']['serviceCatalog']:


### PR DESCRIPTION
Previously when a user did not specify a region, only an endpoint with an empty region field would be used. This change is in line with python-keystoneclient behavior and removes the need for a blank region field in the service catalog

Somewhat related to a recent discussion in #10
