### PR TITLE
let standardclient cache regionless auth1 tokens

### DIFF
--- a/swiftly/client/standardclient.py
+++ b/swiftly/client/standardclient.py
@@ -156,7 +156,7 @@ class StandardClient(Client):
                 self.auth_cache_path)
             data = '\n'.join([
                 self.auth_url, self.auth_user, self.auth_key,
-                self.auth_tenant or '', self.region, self.storage_url,
+                self.auth_tenant or '', self.region or '', self.storage_url,
                 self.cdn_url or '', self.auth_token, str(self.snet)])
             fp, path = tempfile.mkstemp()
             os.write(fp, data.encode('base64'))


### PR DESCRIPTION
When an auth1 url is given with no `auth_region` and `cache_auth` is enabled then swiftly bombs out like this in _auth_save_cache because region is None. Letting it become '' like the other non-essential fields lets it save fine.

```
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/swiftly/client/standardclient.py", line 160, in _auth_save_cache
    self.cdn_url or '', self.auth_token, str(self.snet)])
TypeError: sequence item 4: expected string, NoneType found
```
