### PR TITLE
python3: fix obvious compatibility issues

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from six import moves
 from os import walk
 from os.path import dirname, join as path_join, sep as path_sep
 from subprocess import Popen
@@ -80,7 +81,7 @@ with open(path_join(topdir, 'doc', 'cli.rst'), 'w') as fp:
     fp.write('=================\n')
     fp.write('\n')
     commands = swiftly.cli.cli.COMMANDS
-    for index in xrange(len(commands)):
+    for index in moves.range(len(commands)):
         name = commands[index].split('.')[2]
         if name == 'help':
             commands[index] = ''

--- a/swiftly/cli/auth.py
+++ b/swiftly/cli/auth.py
@@ -37,9 +37,8 @@ def cli_auth(context):
 
     See :py:class:`CLIAuth` for more information.
     """
-    with contextlib.nested(
-            context.io_manager.with_stdout(),
-            context.client_manager.with_client()) as (fp, client):
+    with context.io_manager.with_stdout() as fp, \
+         context.client_manager.with_client() as client:
         info = []
         client.auth()
         if getattr(client, 'auth_cache_path', None):

--- a/swiftly/cli/cli.py
+++ b/swiftly/cli/cli.py
@@ -16,7 +16,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from ConfigParser import Error as ConfigParserError, SafeConfigParser
+import six
+from six import moves
+from six.moves.configparser import Error as ConfigParserError, SafeConfigParser
 import functools
 import os
 import sys
@@ -249,7 +251,7 @@ configuration file variables.
             command = self.commands[name]
             lines = command.option_parser.get_usage().split('\n')
             main_line = '  ' + lines[0].split(']', 1)[1].strip()
-            for x in xrange(4):
+            for x in moves.range(4):
                 lines.pop(0)
             for x, line in enumerate(lines):
                 if not line:
@@ -315,12 +317,12 @@ configuration file variables.
         for option_name in (
                 'snet', 'no_snet', 'cache_auth', 'no_cache_auth', 'cdn',
                 'no_cdn', 'eventlet', 'no_eventlet', 'verbose', 'no_verbose'):
-            if isinstance(getattr(options, option_name), basestring):
+            if isinstance(getattr(options, option_name), six.string_types):
                 setattr(
                     options, option_name,
                     getattr(options, option_name).lower() in TRUE_VALUES)
         for option_name in ('retries', 'concurrency'):
-            if isinstance(getattr(options, option_name), basestring):
+            if isinstance(getattr(options, option_name), six.string_types):
                 setattr(
                     options, option_name, int(getattr(options, option_name)))
         if options.snet is None:

--- a/swiftly/cli/context.py
+++ b/swiftly/cli/context.py
@@ -38,11 +38,7 @@ class CLIContext(object):
             return None
 
     def __repr__(self):
-        result = super(CLIContext, self).__repr__()
-        for item in dir(self):
-            if item[0] != '_' and item != 'copy':
-                result += '\n    %s = %s' % (item, getattr(self, item))
-        return result
+        return str(vars(self))
 
     def copy(self):
         """

--- a/swiftly/cli/delete.py
+++ b/swiftly/cli/delete.py
@@ -30,6 +30,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import six
 from swiftly.concurrency import Concurrency
 from swiftly.cli.command import CLICommand, ReturnCode
 
@@ -102,7 +103,7 @@ def cli_empty_container(context, path, until_empty=False):
 
     def check_conc():
         for (exc_type, exc_value, exc_tb, result) in \
-                conc.get_results().itervalues():
+                six.itervalues(conc.get_results()):
             if exc_value:
                 with context.io_manager.with_stderr() as fp:
                     fp.write(str(exc_value))

--- a/swiftly/cli/fordo.py
+++ b/swiftly/cli/fordo.py
@@ -50,7 +50,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import urllib
+import six
+from six.moves import urllib_parse as parse
 
 from swiftly.cli.cli import CLI
 from swiftly.cli.command import CLICommand, ReturnCode
@@ -61,7 +62,7 @@ def _cli_call(context, name, args):
     if context.output_names:
         with context.io_manager.with_stdout() as fp:
             fp.write('Item Name: ')
-            fp.write(urllib.quote(name.encode('utf8')))
+            fp.write(parse.quote(name.encode('utf8')))
             fp.write('\n')
             fp.flush()
     return CLI()(context.original_main_args + args)
@@ -121,7 +122,7 @@ def cli_fordo(context, path=None):
                     'No "<item>" designation found in the "do" clause.')
             args[index] = name
             for (exc_type, exc_value, exc_tb, result) in \
-                    conc.get_results().itervalues():
+                    six.itervalues(conc.get_results()):
                 if exc_value:
                     conc.join()
                     raise exc_value
@@ -131,7 +132,7 @@ def cli_fordo(context, path=None):
             break
     conc.join()
     for (exc_type, exc_value, exc_tb, result) in \
-            conc.get_results().itervalues():
+            six.itervalues(conc.get_results()):
         if exc_value:
             conc.join()
             raise exc_value

--- a/swiftly/cli/get.py
+++ b/swiftly/cli/get.py
@@ -66,6 +66,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import six
 import os
 import time
 
@@ -141,7 +142,7 @@ def cli_get_account_listing(context):
                             item.get('bytes', '-'),
                             item.get('count', '-')))
                     fp.write(item.get(
-                        'name', item.get('subdir')).encode('utf8'))
+                        'name', item.get('subdir')))
                     fp.write('\n')
                 fp.flush()
         if limit:
@@ -227,7 +228,7 @@ def cli_get_container_listing(context, path=None):
             for item in contents:
                 if 'name' in item:
                     for (exc_type, exc_value, exc_tb, result) in \
-                            conc.get_results().itervalues():
+                            six.itervalues(conc.get_results()):
                         if exc_value:
                             conc.join()
                             raise exc_value
@@ -244,7 +245,7 @@ def cli_get_container_listing(context, path=None):
                             item.get('hash', '-'),
                             item.get('content_type', '-')))
                     fp.write(item.get(
-                        'name', item.get('subdir')).encode('utf8'))
+                        'name', item.get('subdir')))
                     fp.write('\n')
                 fp.flush()
         if limit:
@@ -264,7 +265,7 @@ def cli_get_container_listing(context, path=None):
                     'listing container %r: %s %s' % (path, status, reason))
     conc.join()
     for (exc_type, exc_value, exc_tb, result) in \
-            conc.get_results().itervalues():
+        six.itervalues(conc.get_results()):
         if exc_value:
             raise exc_value
 

--- a/swiftly/cli/put.py
+++ b/swiftly/cli/put.py
@@ -50,6 +50,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import six
 import json
 import os
 
@@ -100,7 +101,7 @@ def cli_put_directory_structure(context, path):
                 new_path += '/'
             new_path += dirpath[ilen:]
             for (exc_type, exc_value, exc_tb, result) in \
-                    conc.get_results().itervalues():
+                    six.itervalues(conc.get_results()):
                 if exc_value:
                     conc.join()
                     raise exc_value
@@ -116,14 +117,14 @@ def cli_put_directory_structure(context, path):
                     new_path += dirpath[ilen:] + '/'
                 new_path += fname
                 for (exc_type, exc_value, exc_tb, result) in \
-                        conc.get_results().itervalues():
+                        six.itervalues(conc.get_results()):
                     if exc_value:
                         conc.join()
                         raise exc_value
                 conc.spawn(new_path, cli_put_object, new_context, new_path)
     conc.join()
     for (exc_type, exc_value, exc_tb, result) in \
-            conc.get_results().itervalues():
+            six.itervalues(conc.get_results()):
         if exc_value:
             raise exc_value
 
@@ -268,7 +269,7 @@ def cli_put_object(context, path):
                 new_context.seek = start
                 new_path = '%s%08d' % (prefix, segment)
                 for (ident, (exc_type, exc_value, exc_tb, result)) in \
-                        conc.get_results().iteritems():
+                        six.iteritems(conc.get_results()):
                     if exc_value:
                         conc.join()
                         raise exc_value
@@ -279,14 +280,14 @@ def cli_put_object(context, path):
                 start += context.segment_size
             conc.join()
             for (ident, (exc_type, exc_value, exc_tb, result)) in \
-                    conc.get_results().iteritems():
+                    six.iteritems(conc.get_results()):
                 if exc_value:
                     raise exc_value
                 path2info[ident] = result
             if context.static_segments:
                 body = json.dumps([
                     {'path': '/' + p, 'size_bytes': s, 'etag': e}
-                    for p, (s, e) in sorted(path2info.iteritems())])
+                    for p, (s, e) in sorted(six.iteritems(path2info))])
                 put_headers['content-length'] = str(len(body))
                 context.query['multipart-manifest'] = 'put'
             else:

--- a/swiftly/client/localclient.py
+++ b/swiftly/client/localclient.py
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import six
+from six import moves
 from contextlib import contextmanager
 from errno import EAGAIN
 from fcntl import flock, LOCK_EX, LOCK_NB
@@ -24,7 +26,7 @@ from os import close as os_close, listdir, mkdir, open as os_open, O_CREAT, \
 from os.path import exists, getsize, isdir, isfile, join as path_join, \
     sep as path_sep
 from sqlite3 import connect, Row
-from StringIO import StringIO
+from six.moves import StringIO
 from time import time
 from uuid import uuid4
 
@@ -71,7 +73,7 @@ def lock_dir(path):
     path = path_join(path, '_-lock')
     fd = os_open(path, O_WRONLY | O_CREAT, 0o0600)
     try:
-        for x in xrange(100):
+        for x in moves.range(100):
             try:
                 flock(fd, LOCK_EX | LOCK_NB)
                 break
@@ -127,7 +129,7 @@ class LocalClient(Client):
         """
         if cdn:
             raise Exception('CDN not yet supported with LocalClient')
-        if isinstance(contents, basestring):
+        if isinstance(contents, six.string_types):
             contents = StringIO(contents)
         if not headers:
             headers = {}
@@ -402,7 +404,7 @@ class LocalClient(Client):
                                 object_name = object_name[:index + 1]
                         objects[object_name] = {
                             'name': object_name, 'bytes': object_size}
-                objects = sorted(objects.itervalues(), key=lambda x: x['name'])
+                objects = sorted(six.itervalues(objects), key=lambda x: x['name'])
                 if marker:
                     objects = [o for o in objects if o['name'] > marker]
                 if end_marker:

--- a/swiftly/client/localmemcache.py
+++ b/swiftly/client/localmemcache.py
@@ -21,6 +21,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import six
 
 class _Node(object):
 
@@ -37,7 +38,7 @@ class LocalMemcache(object):
         self.max_count = 1000
         # Copy all items from the parsed_conf to actual instance attributes.
         if parsed_conf:
-            for k, v in parsed_conf.iteritems():
+            for k, v in six.iteritems(parsed_conf):
                 setattr(self, k, v)
         self.name = name
         self.next_app = next_app
@@ -90,7 +91,7 @@ class LocalMemcache(object):
 
     def set_multi(self, mapping, server_key, serialize=True, timeout=0,
                   time=0):
-        for key, value in mapping.iteritems():
+        for key, value in six.iteritems(mapping):
             self.set(key, value)
 
     def get_multi(self, keys, server_key):

--- a/swiftly/client/manager.py
+++ b/swiftly/client/manager.py
@@ -18,7 +18,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import contextlib
-import Queue
+from six.moves import queue
 
 
 class ClientManager(object):
@@ -35,7 +35,7 @@ class ClientManager(object):
         self.client_class = client_class
         self.args = args
         self.kwargs = kwargs
-        self.clients = Queue.Queue()
+        self.clients = queue.Queue()
         self.client_id = 0
 
     def get_client(self):
@@ -46,7 +46,7 @@ class ClientManager(object):
         client = None
         try:
             client = self.clients.get(block=False)
-        except Queue.Empty:
+        except queue.Empty:
             pass
         if not client:
             self.client_id += 1

--- a/swiftly/client/standardclient.py
+++ b/swiftly/client/standardclient.py
@@ -16,13 +16,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import six
 import errno
 import json
 import os
-import StringIO
+from six.moves import StringIO
 import tempfile
-import urlparse
+from six.moves import urllib_parse as urlparse
 from time import time
+from codecs import encode, decode
 
 from swiftly.client.client import Client
 from swiftly.client.utils import quote, headers_to_dict
@@ -104,7 +106,7 @@ class StandardClient(Client):
         self.default_region = None
         self.storage_url = None
         self.cdn_url = None
-        self.conn_discard = None
+        self.conn_discard = 0
         self.storage_conn = None
         self.storage_path = None
         self.cdn_conn = None
@@ -130,7 +132,7 @@ class StandardClient(Client):
                 except ImportError:
                     pass
             except ImportError:
-                import httplib
+                from six.moves import http_client as httplib
                 self.HTTPConnection = httplib.HTTPConnection
                 self.HTTPSConnection = httplib.HTTPSConnection
                 self.HTTPException = httplib.HTTPException
@@ -141,7 +143,7 @@ class StandardClient(Client):
                 from time import sleep
                 self.sleep = sleep
         else:
-            import httplib
+            from six.moves import http_client as httplib
             self.HTTPConnection = httplib.HTTPConnection
             self.HTTPSConnection = httplib.HTTPSConnection
             self.HTTPException = httplib.HTTPException
@@ -159,14 +161,14 @@ class StandardClient(Client):
                 self.auth_tenant or '', self.region or '', self.storage_url,
                 self.cdn_url or '', self.auth_token, str(self.snet)])
             fp, path = tempfile.mkstemp()
-            os.write(fp, data.encode('base64'))
+            os.write(fp, encode(data.encode('utf-8'), 'base64'))
             os.close(fp)
             os.rename(path, self.auth_cache_path)
 
     def _auth_load_cache(self):
         if self.auth_cache_path:
             try:
-                data = open(self.auth_cache_path, 'r').read().decode('base64')
+                data = decode(open(self.auth_cache_path, 'rb').read(), 'base64').decode('utf-8')
                 data = data.split('\n')
                 if len(data) == 9:
                     (auth_url, auth_user, auth_key, auth_tenant, region,
@@ -342,7 +344,7 @@ class StandardClient(Client):
                 # auth is so huge.
                 # self.verbose('< %s', body)
                 try:
-                    body = json.loads(body)
+                    body = json.loads(body.decode('utf-8'))
                 except ValueError as err:
                     status = 500
                     reason = str(err)
@@ -450,10 +452,10 @@ class StandardClient(Client):
         if query:
             path += '?' + '&'.join(
                 ('%s=%s' % (quote(k), quote(v)) if v else quote(k))
-                for k, v in sorted(query.iteritems()))
+                for k, v in sorted(six.iteritems(query)))
         reset_func = self._default_reset_func
-        if isinstance(contents, basestring):
-            contents = StringIO.StringIO(contents)
+        if isinstance(contents, six.string_types):
+            contents = StringIO(contents)
         tell = getattr(contents, 'tell', None)
         seek = getattr(contents, 'seek', None)
         if tell and seek:
@@ -491,12 +493,12 @@ class StandardClient(Client):
                     raise self.HTTPException(
                         '%s %s failed: No connection' % (method, path))
             self.conn_discard = time() + 4
-            titled_headers = dict((k.title(), v) for k, v in {
+            titled_headers = dict((k.title(), v) for k, v in six.iteritems({
                 'User-Agent': self.user_agent,
-                'X-Auth-Token': self.auth_token}.iteritems())
+                'X-Auth-Token': self.auth_token}))
             if headers:
                 titled_headers.update(
-                    (k.title(), v) for k, v in headers.iteritems())
+                    (k.title(), v) for k, v in six.iteritems(headers))
             try:
                 if not hasattr(contents, 'read'):
                     if method not in self.no_content_methods and contents and \
@@ -506,7 +508,7 @@ class StandardClient(Client):
                             len(contents or ''))
                     verbose_headers = '  '.join(
                         '%s: %s' % (k, v)
-                        for k, v in sorted(titled_headers.iteritems()))
+                        for k, v in sorted(six.iteritems(titled_headers)))
                     self.verbose(
                         '> %s %s %s', method, conn_path + path,
                         verbose_headers)
@@ -515,7 +517,7 @@ class StandardClient(Client):
                 else:
                     conn.putrequest(method, conn_path + path)
                     content_length = None
-                    for h, v in sorted(titled_headers.iteritems()):
+                    for h, v in sorted(six.iteritems(titled_headers)):
                         if h == 'Content-Length':
                             content_length = int(v)
                         conn.putheader(h, v)
@@ -526,7 +528,7 @@ class StandardClient(Client):
                     conn.endheaders()
                     verbose_headers = '  '.join(
                         '%s: %s' % (k, v)
-                        for k, v in sorted(titled_headers.iteritems()))
+                        for k, v in sorted(six.iteritems(titled_headers)))
                     self.verbose(
                         '> %s %s %s', method, conn_path + path,
                         verbose_headers)
@@ -538,7 +540,7 @@ class StandardClient(Client):
                             chunk = contents.read(self.chunk_size)
                         conn.send('0\r\n\r\n')
                     else:
-                        left = content_length
+                        left = content_length or 0
                         while left > 0:
                             size = self.chunk_size
                             if size > left:
@@ -572,7 +574,7 @@ class StandardClient(Client):
             elif status and status // 100 != 5:
                 if not stream and decode_json and status // 100 == 2:
                     if value:
-                        value = json.loads(value)
+                        value = json.loads(value.decode('utf-8'))
                     else:
                         value = None
                 self.conn_discard = time() + 4

--- a/swiftly/client/utils.py
+++ b/swiftly/client/utils.py
@@ -16,10 +16,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import six
 import hashlib
 import hmac
 import time
-import urllib
+from six.moves import urllib_parse as parse
 
 
 def generate_temp_url(method, url, seconds, key):
@@ -55,15 +56,15 @@ def get_trans_id_time(trans_id):
 
 def quote(value, safe='/:'):
     """
-    Much like urllib.quote in that it returns a URL encoded string
+    Much like parse.quote in that it returns a URL encoded string
     for the given value, protecting the safe characters; but this
     version also ensures the value is UTF-8 encoded.
     """
-    if isinstance(value, unicode):
+    if isinstance(value, six.text_type):
         value = value.encode('utf8')
-    elif not isinstance(value, basestring):
+    elif not isinstance(value, six.string_types):
         value = str(value)
-    return urllib.quote(value, safe)
+    return parse.quote(value, safe)
 
 
 def headers_to_dict(headers):

--- a/swiftly/concurrency.py
+++ b/swiftly/concurrency.py
@@ -19,14 +19,14 @@ limitations under the License.
 __all__ = ['Concurrency']
 
 import sys
-import Queue
+from six.moves import queue
 
 try:
     from eventlet import GreenPool, sleep, Timeout
 except ImportError:
     GreenPool = None
     sleep = None
-    Timeout = None
+    Timeout = Exception
 
 
 class Concurrency(object):
@@ -43,7 +43,7 @@ class Concurrency(object):
             self._pool = GreenPool(self.concurrency)
         else:
             self._pool = None
-        self._queue = Queue.Queue()
+        self._queue = queue.Queue()
         self._results = {}
 
     def _spawner(self, ident, func, *args, **kwargs):
@@ -95,7 +95,7 @@ class Concurrency(object):
             while True:
                 ident, value = self._queue.get(block=False)
                 self._results[ident] = value
-        except Queue.Empty:
+        except queue.Empty:
             pass
         return self._results
 

--- a/swiftly/filelikeiter.py
+++ b/swiftly/filelikeiter.py
@@ -34,9 +34,9 @@ class FileLikeIter(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         """
-        x.next() -> the next value, or raise StopIteration
+        x.__next__() -> the next value, or raise StopIteration
         """
         if self.closed:
             raise ValueError('I/O operation on closed file')
@@ -45,7 +45,7 @@ class FileLikeIter(object):
             self.buf = None
             return rv
         else:
-            return self.iterator.next()
+            return next(self.iterator)
 
     def read(self, size=-1):
         """
@@ -66,7 +66,7 @@ class FileLikeIter(object):
             self.buf = None
         else:
             try:
-                chunk = self.iterator.next()
+                chunk = next(self.iterator)
             except StopIteration:
                 return ''
         if len(chunk) > size:


### PR DESCRIPTION
There are likely still some logic issues that need to be found.

This breaks compatibility with python <=2.6 in places.