### PR TITLE
Stdin segmentation

### DIFF
--- a/swiftly/cli/put.py
+++ b/swiftly/cli/put.py
@@ -35,8 +35,6 @@ static_segments  Set to True to use static large object support
                  instead of dynamic large object support.
 ===============  ====================================================
 """
-import select
-
 """
 Copyright 2011-2013 Gregory Holt
 
@@ -191,7 +189,6 @@ def cli_put_object(context, path):
 
     See :py:class:`CLIPut` for more information.
     """
-
     if context.different and context.encrypt:
         raise ReturnCode(
             'context.different will not work properly with context.encrypt '
@@ -206,24 +203,30 @@ def cli_put_object(context, path):
         if context.stdin_segmentation:
             def reader():
                 while True:
-                    chunk = stdin.read(2**20)
+                    chunk = stdin.read(65536)
                     if chunk:
                         yield chunk
                     else:
                         return
 
-            body = FileLikeIter(reader(), context.segment_size)
+            segment_body = FileLikeIter(reader(), context.segment_size)
 
             prefix = _create_container(context, path, time.time(), 0)
             new_context = context.copy()
             new_context.stdin_segmentation = False
-            new_context.stdin = body
+            new_context.stdin = segment_body
             new_context.headers = dict(context.headers)
-            segment = 0
-            while not body.is_empty():
-                cli_put_object(new_context, _segment_path(prefix, segment))
-                segment += 1
-                body.reset_limit()
+            segment_n = 0
+            path2info = {}
+            while not segment_body.is_empty():
+                segment_path = _get_segment_path(prefix, segment_n)
+                etag = cli_put_object(new_context, segment_path)
+                size = segment_body.limit - segment_body.left
+                path2info[segment_path] = (size, etag)
+
+                segment_body.reset_limit()
+                segment_n += 1
+            body = _get_manifest_body(context, prefix, path2info, put_headers)
         else:
             if hasattr(context, 'stdin'):
                 body = context.stdin
@@ -290,7 +293,7 @@ def cli_put_object(context, path):
                 new_context.headers['content-length'] = str(min(
                     size - start, context.segment_size))
                 new_context.seek = start
-                new_path = _segment_path(prefix, segment)
+                new_path = _get_segment_path(prefix, segment)
                 for (ident, (exc_type, exc_value, exc_tb, result)) in \
                         conc.get_results().iteritems():
                     if exc_value:
@@ -307,16 +310,7 @@ def cli_put_object(context, path):
                 if exc_value:
                     raise exc_value
                 path2info[ident] = result
-            if context.static_segments:
-                body = json.dumps([
-                    {'path': '/' + p, 'size_bytes': s, 'etag': e}
-                    for p, (s, e) in sorted(path2info.iteritems())])
-                put_headers['content-length'] = str(len(body))
-                context.query['multipart-manifest'] = 'put'
-            else:
-                body = ''
-                put_headers['content-length'] = '0'
-                put_headers['x-object-manifest'] = prefix
+            body = _get_manifest_body(context, prefix, path2info, put_headers)
         else:
             body = open(context.input_, 'rb')
     with context.client_manager.with_client() as client:
@@ -366,6 +360,8 @@ def cli_put_object(context, path):
             if content_length:
                 content_length = int(content_length)
         return content_length, etag
+    if context.stdin is not None:
+        return headers.get('etag')
 
 
 def cli_put(context, path):
@@ -387,11 +383,38 @@ def cli_put(context, path):
         return cli_put_object(context, path)
 
 
-def _segment_path(prefix, segment):
-    return '%s%08d' % (prefix, segment)
+def _get_segment_path(prefix, n):
+    """
+    Returns segment path for nth segment
+    """
+    return '%s%08d' % (prefix, n)
+
+
+def _get_manifest_body(context, prefix, path2info, put_headers):
+    """
+    Returns body for manifest file and modifies put_headers.
+
+    path2info is a dict like {"path": (size, etag)}
+    """
+    if context.static_segments:
+        body = json.dumps([
+            {'path': '/' + p, 'size_bytes': s, 'etag': e}
+            for p, (s, e) in sorted(path2info.iteritems())
+        ])
+        put_headers['content-length'] = str(len(body))
+        context.query['multipart-manifest'] = 'put'
+    else:
+        body = ''
+        put_headers['content-length'] = '0'
+        put_headers['x-object-manifest'] = prefix
+
+    return body
 
 
 def _create_container(context, path, l_mtime, size):
+    """
+    Creates container for segments of file with `path`
+    """
     new_context = context.copy()
     new_context.input_ = None
     new_context.headers = None
@@ -400,6 +423,7 @@ def _create_container(context, path, l_mtime, size):
     cli_put_container(new_context, container)
     prefix = container + '/' + path.split('/', 1)[1]
     prefix = '%s/%s/%s/' % (prefix, l_mtime, size)
+
     return prefix
 
 

--- a/swiftly/cli/put.py
+++ b/swiftly/cli/put.py
@@ -35,6 +35,8 @@ static_segments  Set to True to use static large object support
                  instead of dynamic large object support.
 ===============  ====================================================
 """
+import select
+
 """
 Copyright 2011-2013 Gregory Holt
 
@@ -52,6 +54,7 @@ limitations under the License.
 """
 import json
 import os
+import time
 
 from swiftly.cli.command import CLICommand, ReturnCode
 from swiftly.concurrency import Concurrency
@@ -188,6 +191,7 @@ def cli_put_object(context, path):
 
     See :py:class:`CLIPut` for more information.
     """
+
     if context.different and context.encrypt:
         raise ReturnCode(
             'context.different will not work properly with context.encrypt '
@@ -197,7 +201,34 @@ def cli_put_object(context, path):
         body = ''
         put_headers['content-length'] = '0'
     elif not context.input_ or context.input_ == '-':
-        body = context.io_manager.get_stdin()
+        stdin = context.io_manager.get_stdin()
+
+        if context.stdin_segmentation:
+            def reader():
+                while True:
+                    chunk = stdin.read(2**20)
+                    if chunk:
+                        yield chunk
+                    else:
+                        return
+
+            body = FileLikeIter(reader(), context.segment_size)
+
+            prefix = _create_container(context, path, time.time(), 0)
+            new_context = context.copy()
+            new_context.stdin_segmentation = False
+            new_context.stdin = body
+            new_context.headers = dict(context.headers)
+            segment = 0
+            while not body.is_empty():
+                cli_put_object(new_context, _segment_path(prefix, segment))
+                segment += 1
+                body.reset_limit()
+        else:
+            if hasattr(context, 'stdin'):
+                body = context.stdin
+            else:
+                body = stdin
     elif context.seek is not None:
         if context.encrypt:
             raise ReturnCode(
@@ -248,14 +279,7 @@ def cli_put_object(context, path):
                 raise ReturnCode(
                     'putting object %r: Cannot use encryption for objects '
                     'greater than the segment size' % path)
-            new_context = context.copy()
-            new_context.input_ = None
-            new_context.headers = None
-            new_context.query = None
-            container = path.split('/', 1)[0] + '_segments'
-            cli_put_container(new_context, container)
-            prefix = container + '/' + path.split('/', 1)[1]
-            prefix = '%s/%s/%s/' % (prefix, l_mtime, size)
+            prefix = _create_container(context, path, l_mtime, size)
             conc = Concurrency(context.concurrency)
             start = 0
             segment = 0
@@ -266,7 +290,7 @@ def cli_put_object(context, path):
                 new_context.headers['content-length'] = str(min(
                     size - start, context.segment_size))
                 new_context.seek = start
-                new_path = '%s%08d' % (prefix, segment)
+                new_path = _segment_path(prefix, segment)
                 for (ident, (exc_type, exc_value, exc_tb, result)) in \
                         conc.get_results().iteritems():
                     if exc_value:
@@ -361,6 +385,22 @@ def cli_put(context, path):
         return cli_put_container(context, path)
     else:
         return cli_put_object(context, path)
+
+
+def _segment_path(prefix, segment):
+    return '%s%08d' % (prefix, segment)
+
+
+def _create_container(context, path, l_mtime, size):
+    new_context = context.copy()
+    new_context.input_ = None
+    new_context.headers = None
+    new_context.query = None
+    container = path.split('/', 1)[0] + '_segments'
+    cli_put_container(new_context, container)
+    prefix = container + '/' + path.split('/', 1)[1]
+    prefix = '%s/%s/%s/' % (prefix, l_mtime, size)
+    return prefix
 
 
 class CLIPut(CLICommand):
@@ -466,6 +506,10 @@ http://greg.brim.net/post/2013/05/16/1834.html""".strip())
                  'as a segmented object. See full help text for more '
                  'information.')
         self.option_parser.add_option(
+            '--stdin-segmentation', dest='stdin_segmentation', action='store_true',
+            help='Separate STDIN data into segments. This will separate data'
+            'even if segment size is not exceeded.')
+        self.option_parser.add_option(
             '--encrypt', dest='encrypt', metavar='KEY',
             help='Will encrypt the uploaded object data with KEY. This '
                  'currently uses AES 256 in CBC mode but other algorithms may '
@@ -487,6 +531,7 @@ http://greg.brim.net/post/2013/05/16/1834.html""".strip())
             context.segment_size or 5 * 1024 * 1024 * 1024)
         if context.segment_size < 1:
             raise ReturnCode('invalid segment size %s' % options.segment_size)
+        context.stdin_segmentation = options.stdin_segmentation
         context.empty = options.empty
         context.newer = options.newer
         context.different = options.different

--- a/swiftly/filelikeiter.py
+++ b/swiftly/filelikeiter.py
@@ -26,8 +26,10 @@ class FileLikeIter(object):
     OpenStack Foundation.
     """
 
-    def __init__(self, iterable):
+    def __init__(self, iterable, limit=None):
         self.iterator = iter(iterable)
+        self.limit = limit
+        self.left = limit
         self.buf = None
         self.closed = False
 
@@ -47,6 +49,9 @@ class FileLikeIter(object):
         else:
             return self.iterator.next()
 
+    def reset_limit(self):
+        self.left = self.limit
+
     def read(self, size=-1):
         """
         read([size]) -> read at most size bytes, returned as a string.
@@ -55,6 +60,8 @@ class FileLikeIter(object):
         Notice that when in non-blocking mode, less data than what was
         requested may be returned, even if no size parameter was given.
         """
+        if self.left is not None:
+            size = min(size, self.left)
         if self.closed:
             raise ValueError('I/O operation on closed file')
         if size < 0:
@@ -72,6 +79,8 @@ class FileLikeIter(object):
         if len(chunk) > size:
             self.buf = chunk[size:]
             chunk = chunk[:size]
+        if self.left is not None:
+            self.left -= len(chunk)
         return chunk
 
     def readline(self, size=-1):
@@ -123,6 +132,17 @@ class FileLikeIter(object):
                 if sizehint <= 0:
                     break
         return lines
+
+    def is_empty(self):
+        something = self.read(1)
+        if something:
+            if self.buf:
+                self.buf = something + self.buf
+            else:
+                self.buf = something
+            return False
+        else:
+            return True
 
     def close(self):
         """

--- a/swiftly/filelikeiter.py
+++ b/swiftly/filelikeiter.py
@@ -50,6 +50,9 @@ class FileLikeIter(object):
             return self.iterator.next()
 
     def reset_limit(self):
+        """
+        Resets the limit.
+        """
         self.left = self.limit
 
     def read(self, size=-1):
@@ -134,6 +137,9 @@ class FileLikeIter(object):
         return lines
 
     def is_empty(self):
+        """
+        Check whether the "file" is empty reading the single byte.
+        """
         something = self.read(1)
         if something:
             if self.buf:


### PR DESCRIPTION
Hello.

I and my coworkers really need to upload long file from `stdin`, so I added `--stdin-segmentation` flag, that allows you to do that.

The current solution is a bit hacky, I just wrap `stdin` with a object that doesn't allow to read more than segment size within one `cli_put_object` call. That is also pretty slow, but that's the easiest thing I could invent.

Also, you maybe want to review my comments and function names, I'm open to any comments.

