### PR TITLE
Add setup.py dependency on six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,4 @@ setup(
     author='Gregory Holt', author_email='swiftly@brim.net',
     url='http://gholt.github.com/swiftly/',
     packages=['swiftly', 'swiftly.cli', 'swiftly.client'],
-    scripts=['bin/swiftly'])
+    scripts=['bin/swiftly'], install_requires=['six'])


### PR DESCRIPTION
Merging #60 introduced a dependency on six, without ensuring it would be pulled in on `pip install`.