### PR TITLE
Add bypass URL option

### DIFF
--- a/swiftly/cli/cli.py
+++ b/swiftly/cli/cli.py
@@ -179,6 +179,9 @@ configuration file variables.
             '-P', '--proxy', dest='proxy', metavar='URL',
             help='Uses the given HTTP proxy URL.')
         self.option_parser.add_option(
+            '-B', '--bypass-url', dest='bypass_url', metavar='URL',
+            help='Override Swift endpoint URL provided during authentication.')
+        self.option_parser.add_option(
             '-S', '--snet', dest='snet', action='store_true',
             help='Prepends the storage URL host name with "snet-". Mostly '
                  'only useful with Rackspace Cloud Files and Rackspace '
@@ -315,7 +318,7 @@ configuration file variables.
                 'auth_methods', 'region', 'direct', 'local', 'proxy', 'snet',
                 'no_snet', 'retries', 'cache_auth', 'no_cache_auth', 'cdn',
                 'no_cdn', 'concurrency', 'eventlet', 'no_eventlet', 'verbose',
-                'no_verbose', 'direct_object_ring', 'insecure'):
+                'no_verbose', 'direct_object_ring', 'insecure', 'bypass_url'):
             self._resolve_option(options, option_name, 'swiftly')
         for option_name in (
                 'snet', 'no_snet', 'cache_auth', 'no_cache_auth', 'cdn',
@@ -419,7 +422,8 @@ configuration file variables.
                 auth_cache_path=auth_cache_path, region=options.region,
                 snet=options.snet, attempts=options.retries + 1,
                 eventlet=self.context.eventlet, verbose=self._verbose,
-                http_proxy=options.proxy, insecure=options.insecure)
+                http_proxy=options.proxy, insecure=options.insecure,
+                bypass_url=options.bypass_url)
 
         self.context.cdn = options.cdn
         self.context.concurrency = int(options.concurrency)

--- a/swiftly/client/standardclient.py
+++ b/swiftly/client/standardclient.py
@@ -74,13 +74,15 @@ class StandardClient(Client):
     :param verbose_id: Set to a string you wish verbose messages to
         be prepended with; can help in identifying output when
         multiple Clients are in use.
+    :param bypass_url: The URL to override the storage and CDN URL
+        received during authentication.
     """
 
     def __init__(self, auth_methods=None, auth_url=None, auth_tenant=None,
                  auth_user=None, auth_key=None, auth_cache_path=None,
                  region=None, snet=False, attempts=5, eventlet=None,
                  chunk_size=65536, http_proxy=None, verbose=None,
-                 verbose_id='', insecure=False):
+                 verbose_id='', insecure=False, bypass_url=None):
         super(StandardClient, self).__init__()
         self.auth_methods = auth_methods
         self.auth_url = auth_url.rstrip('/') if auth_url else None
@@ -93,6 +95,7 @@ class StandardClient(Client):
         self.attempts = attempts
         self.chunk_size = chunk_size
         self.http_proxy = http_proxy
+        self.bypass_url = bypass_url.rstrip('/') if bypass_url else None
         if verbose:
             self.verbose = lambda m, *a, **k: verbose(
                 self._verbose_id + m, *a, **k)
@@ -428,6 +431,10 @@ class StandardClient(Client):
                 if not self.storage_url:
                     self.auth()
                 url = self.storage_url
+
+            if self.bypass_url:
+                self.verbose('Bypassing %s with %s', url, self.bypass_url)
+                url = self.bypass_url
         parsed = urlparse.urlparse(url) if url else None
         http_proxy_parsed = \
             urlparse.urlparse(self.http_proxy) if self.http_proxy else None


### PR DESCRIPTION
Allow the user to override the storage and CDN URLs provided during
authentication with a specified URL.

This is sometimes necessary to work around an incorrect service
catalog entry or target a specific node other than the one in the
service catalog (eg behind a load-balancer, hot standby).